### PR TITLE
Fix crash when IC2 API is present but not properly initialized

### DIFF
--- a/java/defeatedcrow/addonforamt/economy/common/block/GeneratorBase.java
+++ b/java/defeatedcrow/addonforamt/economy/common/block/GeneratorBase.java
@@ -1,5 +1,6 @@
 package defeatedcrow.addonforamt.economy.common.block;
 
+import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergySource;
 import mods.defeatedcrow.api.charge.IChargeGenerator;
 import mods.defeatedcrow.api.charge.IChargeableMachine;
@@ -46,7 +47,7 @@ public abstract class GeneratorBase extends TileEntity implements ISidedInventor
 
 	public GeneratorBase() {
 		super();
-		if (ModAPIManager.INSTANCE.hasAPI("IC2API")) {
+		if (ModAPIManager.INSTANCE.hasAPI("IC2API") && EnergyNet.instance != null) {
 			EUChannel = EUSourceManagerEMT.getChannel(this, this.getMaxChargeAmount() * exchangeRateEU(), 1);
 		}
 	}

--- a/java/defeatedcrow/addonforamt/economy/common/block/TileENMotor.java
+++ b/java/defeatedcrow/addonforamt/economy/common/block/TileENMotor.java
@@ -1,5 +1,6 @@
 package defeatedcrow.addonforamt.economy.common.block;
 
+import ic2.api.energy.EnergyNet;
 import mods.defeatedcrow.api.charge.ChargeItemManager;
 import mods.defeatedcrow.api.charge.IChargeGenerator;
 import mods.defeatedcrow.api.charge.IChargeItem;
@@ -57,7 +58,7 @@ public class TileENMotor extends TileEntity implements ISidedInventory, IChargea
 
 	public TileENMotor() {
 		super();
-		if (ModAPIManager.INSTANCE.hasAPI("IC2API")) {
+		if (ModAPIManager.INSTANCE.hasAPI("IC2API") && EnergyNet.instance != null) {
 			EUChannel = EUSinkManagerEMT.getChannel(this, 128, 3);
 		}
 	}


### PR DESCRIPTION
We had an odd crash on our server that I traced down to the IC2 API being detected as present, but EnergyNet.instance was not initialized (null). This is an additional safety check to insure the API is present and initialized.
